### PR TITLE
Improve 4337 Compatibility

### DIFF
--- a/contracts/deployments.json
+++ b/contracts/deployments.json
@@ -1,6 +1,6 @@
 {
   "1337": {
-    "Shadowlings": "0x64509Ae204721D612660A94597aF37e073d829F6",
+    "Shadowlings": "0xB1DA1b7e0f0336698656456679823d6de52F17a4",
     "ShadowToken": "0x4670c975c6267ce403d7B20ca5dF8Ca29956BCe4"
   }
 }

--- a/contracts/src/verifiers/main/Verifier.sol
+++ b/contracts/src/verifiers/main/Verifier.sol
@@ -45,9 +45,7 @@ library Pairing {
         input[3] = p2.Y;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            success := staticcall(gas(), 6, input, 0xc0, r, 0x60)
         }
         require(success);
     }
@@ -62,9 +60,7 @@ library Pairing {
         input[2] = s;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            success := staticcall(gas(), 7, input, 0x80, r, 0x60)
         }
         require (success);
     }
@@ -89,9 +85,7 @@ library Pairing {
         uint[1] memory out;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            success := staticcall(gas(), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
         }
         require(success);
         return out[0] != 0;

--- a/contracts/src/verifiers/recovery/Verifier.sol
+++ b/contracts/src/verifiers/recovery/Verifier.sol
@@ -45,9 +45,7 @@ library Pairing {
         input[3] = p2.Y;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            success := staticcall(gas(), 6, input, 0xc0, r, 0x60)
         }
         require(success);
     }
@@ -62,9 +60,7 @@ library Pairing {
         input[2] = s;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            success := staticcall(gas(), 7, input, 0x80, r, 0x60)
         }
         require (success);
     }
@@ -89,9 +85,7 @@ library Pairing {
         uint[1] memory out;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            success := staticcall(gas(), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
         }
         require(success);
         return out[0] != 0;

--- a/contracts/src/verifiers/register/Verifier.sol
+++ b/contracts/src/verifiers/register/Verifier.sol
@@ -45,9 +45,7 @@ library Pairing {
         input[3] = p2.Y;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            success := staticcall(gas(), 6, input, 0xc0, r, 0x60)
         }
         require(success);
     }
@@ -62,9 +60,7 @@ library Pairing {
         input[2] = s;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            success := staticcall(gas(), 7, input, 0x80, r, 0x60)
         }
         require (success);
     }
@@ -89,9 +85,7 @@ library Pairing {
         uint[1] memory out;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
+            success := staticcall(gas(), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
         }
         require(success);
         return out[0] != 0;


### PR DESCRIPTION
The generated verifyer contracts are not compatible with 4337 because of their use of `GAS` opcode when calling pairing precompiles. It looks like it was setup this way for gas estimation reasons, but it does not seem to affect our uses (all the tools and scripts run as expected).

With this change, I can execute a 4337 user operation without running the bundler in `--unsafe` mode.

The specific bundler rule that is being violated is [`OP-012`](https://ercs.ethereum.org/ERCS/erc-7562#opcode-rules):

> `GAS` (`0x5A`) opcode is allowed, but only if followed immediately by `*CALL` instructions, else it is blocked. This is a common way to pass all remaining gas to an external call, and it means that the actual value is consumed from the stack immediately and cannot be accessed by any other opcode.